### PR TITLE
Make the plugin work with multi language functionality

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -119,7 +119,7 @@ class format_buttons_renderer extends format_topics_renderer
             if (isset($course->{'divisor' . $currentdivisor}) &&
                 $course->{'divisor' . $currentdivisor} != 0 &&
                 !isset($divisorshow[$currentdivisor])) {
-                $currentdivisorhtml = $course->{'divisortext' . $currentdivisor};
+                $currentdivisorhtml = format_string($course->{'divisortext' . $currentdivisor});
                 $currentdivisorhtml = str_replace('[br]', '<br>', $currentdivisorhtml);
                 $currentdivisorhtml = html_writer::tag('div', $currentdivisorhtml, ['class' => 'divisortext']);
                 if ($course->inlinesections) {


### PR DESCRIPTION
As commented in iarenaza/moodle-filter_multilang2#11, there needs to be a call to either format_string() or format_text() for the filters to be applied to content to be shown to users. In this particular case, format_string() is the sensible choice. So we need to add a call to format_string in line https://github.com/brandaorodrigo/moodle-format_buttons/blob/master/renderer.php#L122.

This would close issue #22